### PR TITLE
PIZ-7: Create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+#### 🤔 Why?
+
+- Summarize why you're making these changes, using bullet points
+
+#### 🛠 What I changed:
+
+- List out what you changed in simple English, using bullet points
+
+#### 🗃️ Trello Issues:
+
+- List of Trello issue links, using bullet points - if no issue exists, coordinate with team lead to make one
+
+#### 🚦 Functional Testing Results:
+
+- List of tests performed, using bullet points and/or screenshots as needed (i.e., "Functionally tested Checkout on localhost" or "Here is the script output results")


### PR DESCRIPTION
#### 🤔 Why?

- To standardize a friendly summary of the PR

#### 🛠 What I changed:

- `.github/pull_request_template.md`: Created .md file with standard template

#### 🗃️ Trello Issues:

- [PIZ7](https://trello.com/c/RnIunWwi/2-piz7-create-and-add-a-pull-request-template)

#### 🚦 Functional Testing Results:

- Done after merge
