### PR TITLE
PIZ1: Fix 'can't create an order' bug

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,11 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route('/', methods=GET)
+def get_sizes():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
#### 🤔 Why?

- To fix a bug where a user couldn't see pizza sizes
- To fix a bug where a user couldn't create an order

#### 🛠 What I changed:

- `app/services/size.py`: added the missing get_sizes() service

#### 🗃️ Trello Issues:

- [PIZ1](https://trello.com/c/SK1nCHCS)

#### 🚦 Functional Testing Results:

- Test passed
![image](https://user-images.githubusercontent.com/104585332/187457790-a337fe5c-b8e0-44b2-b031-5c546a76d12a.png)

- Sizes appearing
![image](https://user-images.githubusercontent.com/104585332/187457865-cd74f6e6-36ef-4983-9cf8-e868042aef3a.png)

- Order created
![image](https://user-images.githubusercontent.com/104585332/187457949-efb8e98b-fde1-422c-83cc-5b7c8c689ae2.png)
![image](https://user-images.githubusercontent.com/104585332/187457998-988824e9-1379-480d-b085-577f9cf872e9.png)
