### PR TITLE
PIZ9: Fix order price calculation

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -12,7 +12,7 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        price = size_price + sum(ingredient.price for ingredient in ingredients)
         return round(price, 2)
 
     @classmethod


### PR DESCRIPTION
#### 🤔 Why?

- So the app calculates the correct order price

#### 🛠 What I changed:

- `app/controllers/order.py`: Added size price to the calculation

#### 🗃️ Trello Issues:

- [PIZ9](https://trello.com/c/C5kSalNE)

#### 🚦 Functional Testing Results:

- Test passed
![image](https://user-images.githubusercontent.com/104585332/187461348-4ab9fabd-8eda-4569-ba1b-c91216fcacff.png)

- UI before:
![image](https://user-images.githubusercontent.com/104585332/187461573-6436b12a-c76b-4580-b058-68027507b20c.png)
![image](https://user-images.githubusercontent.com/104585332/187462013-a91d9ce3-ec8a-4e6d-a12a-7be431de9fd0.png)

- UI after:
![image](https://user-images.githubusercontent.com/104585332/187461715-198c2b41-1237-4ad2-89bb-3ba614341794.png)
![image](https://user-images.githubusercontent.com/104585332/187461902-c101d607-b820-4e8d-a280-3d706ebda342.png)
