### PR TITLE
PIZ10: Update submodule repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pizza-planet-ui"]
 	path = ui
-	url = https://github.com/ioet/pizza-planet-ui
+	url = https://github.com/PVioet/pizza-planet-ui


### PR DESCRIPTION
#### 🤔 Why?

- So the backend's submodule points to the right repository

#### 🛠 What I changed:

- `.gitmodules`: Changed the the url ioet -> PVioet

#### 🗃️ Trello Issues:

- [PIZ10](https://trello.com/c/ejbmC5Cd)

#### 🚦 Functional Testing Results:

- When clicking in the submodule, redirects to the right repository
![image](https://user-images.githubusercontent.com/104585332/187467701-f3ab0bac-e4fb-497b-8c6c-908de2e93179.png)
![image](https://user-images.githubusercontent.com/104585332/187467739-422724e3-240e-4e94-9605-398e409c6ac6.png)
