### PR TITLE
PIZ13: Create a command to empty the DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ python3 manage.py db upgrade
 python3 manage.py seed run
 ```
 
+- Empty the database:
+
+```bash
+python3 manage.py delete
+```
+
 - If you want to use the hot reload feature set FLASK_ENV before running the project:
 
 _For linux/MacOS users:_

--- a/manage.py
+++ b/manage.py
@@ -25,5 +25,12 @@ def test():
     return pytest.main(['-v', './app/test'])
 
 
+@manager.command('delete', with_appcontext=True)
+def delete():
+    for model in [OrderDetail, Order, Beverage, Ingredient, Size]:
+        print(model.query.delete(), f'entries of {model.__name__} deleted')
+    db.session.commit()
+
+
 if __name__ == '__main__':
     manager()


### PR DESCRIPTION
#### 🤔 Why?

- To be able to delete all entries from all tables

#### 🛠 What I changed:

- `manage.py`: Added the delete command

#### 🗃️ Trello Issues:

- [PIZ13](https://trello.com/c/ossgDc2f)

#### 🚦 Functional Testing Results:

- Output
![image](https://user-images.githubusercontent.com/104585332/188039109-c9c88ead-375e-4e58-a9e6-bd8f9ab9eeea.png)

- All tables are empty
![image](https://user-images.githubusercontent.com/104585332/188039172-ba66007d-4fc2-4d3c-bdd4-9f2decc245e5.png)
